### PR TITLE
feat: option to disable constraint signature verification

### DIFF
--- a/builder/config.go
+++ b/builder/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	DiscardRevertibleTxOnErr         bool          `toml:",omitempty"`
 	EnableCancellations              bool          `toml:",omitempty"`
 	BlockProcessorURL                string        `toml:",omitempty"`
+	VerifyConstraints                bool          `toml:",omitempty"`
 }
 
 // DefaultConfig is the default config for the builder.
@@ -58,6 +59,7 @@ var DefaultConfig = Config{
 	BuilderRateLimitMaxBurst:      RateLimitBurstDefault,
 	DiscardRevertibleTxOnErr:      false,
 	EnableCancellations:           false,
+	VerifyConstraints:             true,
 }
 
 // RelayConfig is the config for a single remote relay.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1616,7 +1616,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	cfg.SecondsInSlot = ctx.Uint64(BuilderSecondsInSlot.Name)
 	cfg.DisableBundleFetcher = ctx.IsSet(BuilderDisableBundleFetcher.Name)
 	cfg.DryRun = ctx.IsSet(BuilderDryRun.Name)
-	cfg.VerifyConstraints = ctx.IsSet(BuilderVerifyConstraints.Name)
+	cfg.VerifyConstraints = ctx.Bool(BuilderVerifyConstraints.Name)
 	cfg.IgnoreLatePayloadAttributes = ctx.IsSet(BuilderIgnoreLatePayloadAttributes.Name)
 	cfg.BuilderSecretKey = ctx.String(BuilderSecretKey.Name)
 	cfg.RelaySecretKey = ctx.String(BuilderRelaySecretKey.Name)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -635,6 +635,7 @@ var (
 	BuilderVerifyConstraints = &cli.BoolFlag{
 		Name:     "builder.verify_constraints",
 		Usage:    "Verify signatures on incoming constraints",
+		Value:    true,
 		Category: flags.BuilderCategory,
 	}
 	BuilderBlockValidationBlacklistSourceFilePath = &cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -632,6 +632,11 @@ var (
 		Usage:    "Enable the validator checks",
 		Category: flags.BuilderCategory,
 	}
+	BuilderVerifyConstraints = &cli.BoolFlag{
+		Name:     "builder.verify_constraints",
+		Usage:    "Verify signatures on incoming constraints",
+		Category: flags.BuilderCategory,
+	}
 	BuilderBlockValidationBlacklistSourceFilePath = &cli.StringFlag{
 		Name: "builder.blacklist",
 		Usage: "Path to file containing blacklisted addresses, json-encoded list of strings. " +
@@ -1610,6 +1615,7 @@ func SetBuilderConfig(ctx *cli.Context, cfg *builder.Config) {
 	cfg.SecondsInSlot = ctx.Uint64(BuilderSecondsInSlot.Name)
 	cfg.DisableBundleFetcher = ctx.IsSet(BuilderDisableBundleFetcher.Name)
 	cfg.DryRun = ctx.IsSet(BuilderDryRun.Name)
+	cfg.VerifyConstraints = ctx.IsSet(BuilderVerifyConstraints.Name)
 	cfg.IgnoreLatePayloadAttributes = ctx.IsSet(BuilderIgnoreLatePayloadAttributes.Name)
 	cfg.BuilderSecretKey = ctx.String(BuilderSecretKey.Name)
 	cfg.RelaySecretKey = ctx.String(BuilderRelaySecretKey.Name)


### PR DESCRIPTION
Adds a boolean CLI flag (`--builder.verify_constraints`) that can be set to false to skip constraint signature verification.