### PR TITLE
fix(builder): introduce `updateConstraintsCacheLock`

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -100,6 +100,10 @@ type Builder struct {
 
 	// constraintsCache is a map from slot to the decoded constraints made by proposers
 	constraintsCache *shardmap.FIFOMap[uint64, types.HashToConstraintDecoded]
+	// NOTE: `shardmap` already provides locks, however for handling multiple
+	// relay subscriptions for constraints we need a lock to protect the cache
+	// between the `Get` and `Put` operation
+	updateConstraintsCacheLock sync.Mutex
 
 	limiter                       *rate.Limiter
 	submissionOffsetFromEndOfSlot time.Duration
@@ -393,6 +397,9 @@ func (b *Builder) subscribeToRelayForConstraints(relayBaseEndpoint string) error
 					continue
 				}
 
+				// Take the lock to update the constraints cache: both `Get` and `Put` must be done by the same entity
+				b.updateConstraintsCacheLock.Lock()
+				// For every constraint, we need to check if it has already been seen for the associated slot
 				slotConstraints, _ := b.constraintsCache.Get(constraint.Message.Slot)
 				if len(slotConstraints) == 0 {
 					b.constraintsCache.Put(constraint.Message.Slot, decodedConstraints)
@@ -406,6 +413,7 @@ func (b *Builder) subscribeToRelayForConstraints(relayBaseEndpoint string) error
 				}
 
 				b.constraintsCache.Put(constraint.Message.Slot, slotConstraints)
+				b.updateConstraintsCacheLock.Unlock()
 			}
 		}
 	}

--- a/builder/service.go
+++ b/builder/service.go
@@ -193,7 +193,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 		return errors.New("neither local nor remote relay specified")
 	}
 
-	if len(cfg.SecondaryRemoteRelayEndpoints) > 0 && !(len(cfg.SecondaryRemoteRelayEndpoints) == 1 && cfg.SecondaryRemoteRelayEndpoints[0] == "") {
+	if len(cfg.SecondaryRemoteRelayEndpoints) > 0 && (len(cfg.SecondaryRemoteRelayEndpoints) != 1 || cfg.SecondaryRemoteRelayEndpoints[0] != "") {
 		secondaryRelays := make([]IRelay, len(cfg.SecondaryRemoteRelayEndpoints))
 		for i, endpoint := range cfg.SecondaryRemoteRelayEndpoints {
 			relayConfig, err := getRelayConfig(endpoint)


### PR DESCRIPTION
Introduces a `updateConstraintsCacheLock` on the builder to prevent racing conditions when subscribing to multiple builders for constrains. Even if `shardmap` has inner locks, the following edge case might occur in this code: 

https://github.com/chainbound/bolt-builder/blob/5f66af8685a7bc7c5362a118bed872386f99fdc8/builder/builder.go#L396-L408

1. relay 1 submits constraints A,B,C
2. builder gets constraints from cache, let's assume there is none of them
3. relay 2 submits constraints A,B
4. builder gets constraints from cache, they are still empty
5. builder saves constraints A,B,C from relay 1 with Put
6. builder saves constraints, A,B from relay 2 with Put, overriding the constraints for the slots
