### PR TITLE
fix(sse; cli): avoid infinite loop on possible relay failure; cli flag not passed correctly

### DIFF
--- a/builder/service.go
+++ b/builder/service.go
@@ -290,20 +290,21 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 	}
 
 	builderArgs := BuilderArgs{
-		sk:                            builderSk,
-		blockConsumer:                 blockConsumer,
-		ds:                            ds,
-		dryRun:                        cfg.DryRun,
-		eth:                           ethereumService,
-		relay:                         relay,
-		builderSigningDomain:          builderSigningDomain,
-		builderBlockResubmitInterval:  builderRateLimitInterval,
-		submissionOffsetFromEndOfSlot: submissionOffset,
-		discardRevertibleTxOnErr:      cfg.DiscardRevertibleTxOnErr,
-		ignoreLatePayloadAttributes:   cfg.IgnoreLatePayloadAttributes,
-		validator:                     validator,
 		beaconClient:                  beaconClient,
+		blockConsumer:                 blockConsumer,
+		builderBlockResubmitInterval:  builderRateLimitInterval,
+		builderSigningDomain:          builderSigningDomain,
+		discardRevertibleTxOnErr:      cfg.DiscardRevertibleTxOnErr,
+		dryRun:                        cfg.DryRun,
+		ds:                            ds,
+		eth:                           ethereumService,
+		ignoreLatePayloadAttributes:   cfg.IgnoreLatePayloadAttributes,
 		limiter:                       limiter,
+		relay:                         relay,
+		sk:                            builderSk,
+		submissionOffsetFromEndOfSlot: submissionOffset,
+		validator:                     validator,
+		verifyConstraints:             cfg.VerifyConstraints,
 	}
 
 	builderBackend, err := NewBuilder(builderArgs)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -183,6 +183,7 @@ var (
 		utils.BuilderDiscardRevertibleTxOnErr,
 		utils.BuilderEnableCancellations,
 		utils.BuilderBlockProcessorURL,
+		utils.BuilderVerifyConstraints,
 	}
 
 	rpcFlags = []cli.Flag{


### PR DESCRIPTION
Two things:
- On the Constraints SSE subscription we might run into an infinite loop if we run into an unexpected error. It is better to wait the `retryInterval` and attempt to reconnect.
- The CLI flag `builder.verify_constraints` was not propagated correctly as noted in #7.