### PR TITLE
Revert "fix(builder): introduce `updateConstraintsCacheLock`"

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -100,10 +100,6 @@ type Builder struct {
 
 	// constraintsCache is a map from slot to the decoded constraints made by proposers
 	constraintsCache *shardmap.FIFOMap[uint64, types.HashToConstraintDecoded]
-	// NOTE: `shardmap` already provides locks, however for handling multiple
-	// relay subscriptions for constraints we need a lock to protect the cache
-	// between the `Get` and `Put` operation
-	updateConstraintsCacheLock sync.Mutex
 
 	limiter                       *rate.Limiter
 	submissionOffsetFromEndOfSlot time.Duration
@@ -397,9 +393,6 @@ func (b *Builder) subscribeToRelayForConstraints(relayBaseEndpoint string) error
 					continue
 				}
 
-				// Take the lock to update the constraints cache: both `Get` and `Put` must be done by the same entity
-				b.updateConstraintsCacheLock.Lock()
-				// For every constraint, we need to check if it has already been seen for the associated slot
 				slotConstraints, _ := b.constraintsCache.Get(constraint.Message.Slot)
 				if len(slotConstraints) == 0 {
 					b.constraintsCache.Put(constraint.Message.Slot, decodedConstraints)
@@ -413,7 +406,6 @@ func (b *Builder) subscribeToRelayForConstraints(relayBaseEndpoint string) error
 				}
 
 				b.constraintsCache.Put(constraint.Message.Slot, slotConstraints)
-				b.updateConstraintsCacheLock.Unlock()
 			}
 		}
 	}

--- a/builder/service.go
+++ b/builder/service.go
@@ -193,7 +193,7 @@ func Register(stack *node.Node, backend *eth.Ethereum, cfg *Config) error {
 		return errors.New("neither local nor remote relay specified")
 	}
 
-	if len(cfg.SecondaryRemoteRelayEndpoints) > 0 && (len(cfg.SecondaryRemoteRelayEndpoints) != 1 || cfg.SecondaryRemoteRelayEndpoints[0] != "") {
+	if len(cfg.SecondaryRemoteRelayEndpoints) > 0 && !(len(cfg.SecondaryRemoteRelayEndpoints) == 1 && cfg.SecondaryRemoteRelayEndpoints[0] == "") {
 		secondaryRelays := make([]IRelay, len(cfg.SecondaryRemoteRelayEndpoints))
 		for i, endpoint := range cfg.SecondaryRemoteRelayEndpoints {
 			relayConfig, err := getRelayConfig(endpoint)


### PR DESCRIPTION
Reverts chainbound/bolt-builder#8

Needs better testing